### PR TITLE
Bugfix/internal state transitions fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,30 @@
+name: pysm_env
+channels:
+  - defaults
+dependencies:
+  - bzip2=1.0.8=h2bbff1b_6
+  - ca-certificates=2024.7.2=haa95532_0
+  - colorama=0.4.6=py312haa95532_0
+  - coverage=7.2.2=py312h2bbff1b_0
+  - expat=2.6.2=hd77b12b_0
+  - iniconfig=1.1.1=pyhd3eb1b0_0
+  - libffi=3.4.4=hd77b12b_1
+  - mock=4.0.3=pyhd3eb1b0_0
+  - openssl=3.0.14=h827c3e9_0
+  - packaging=24.1=py312haa95532_0
+  - pip=24.2=py312haa95532_0
+  - pluggy=1.0.0=py312haa95532_1
+  - pytest=7.4.4=py312haa95532_0
+  - pytest-cov=4.1.0=py312haa95532_1
+  - python=3.12.4=h14ffc60_1
+  - setuptools=72.1.0=py312haa95532_0
+  - sqlite=3.45.3=h2bbff1b_0
+  - tk=8.6.14=h0416ee5_0
+  - toml=0.10.2=pyhd3eb1b0_0
+  - tzdata=2024a=h04d1e81_0
+  - vc=14.40=h2eaa2aa_0
+  - vs2015_runtime=14.40.33807=h98bb1dd_0
+  - wheel=0.43.0=py312haa95532_0
+  - xz=5.4.6=h8cc25b3_1
+  - zlib=1.2.13=h8cc25b3_1
+prefix: C:\Users\neilf\AppData\Local\miniconda3\envs\pysm_env

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -1233,7 +1233,7 @@ class StateMachine(State):
                     continue
 
                 t = trans[0]
-                src = t["from_state"].name
+                src = t["from_state"]
                 dest = t["to_state"]
                 if dest is None:
                     dest = src
@@ -1247,7 +1247,7 @@ class StateMachine(State):
                 #     meta = "{" + file + "#" + str(line) + "}"
                 #     evt += f":[[{meta} {fcn.__name__}()]]\\n"
 
-                data += f"\t{src} --> {dest.name}: {evt}\n"
+                data += f"\t{src.name} --> {dest.name}: {evt}\n"
 
         data += "\n"
 
@@ -1271,13 +1271,13 @@ class StateMachine(State):
         """
         Generates D2 state diagram.
 
-        D3 diagrams: https://d2lang.com/
+        D2 diagrams: https://d2lang.com/
 
-        To install the D2 binary:
-        TODO: Instructions
+        To install the D2 binary (necessary dependency), see install instructions
+        https://github.com/terrastruct/d2/blob/master/docs/INSTALL.md
 
         VSCode viewer plugin:
-        TODO: Link
+        https://marketplace.visualstudio.com/items?itemName=terrastruct.d2
 
         Parameters
         ----------

--- a/pysm/pysm.py
+++ b/pysm/pysm.py
@@ -1228,26 +1228,24 @@ class StateMachine(State):
 
         # Add in all of the transitions
         if hasattr(state, "_transitions"):
-            for event, trans in state._transitions._transitions.items():
-                if trans == []:
+            for trans_key, trans_vals in state._transitions._transitions.items():
+                if trans_vals == []:
                     continue
 
-                t = trans[0]
-                src = t["from_state"]
-                dest = t["to_state"]
-                if dest is None:
-                    dest = src
+                evt = str(trans_key[1])
 
-                # Event
-                evt = str(event[1])
-                # fcn = t["condition"]
-                # if fcn.__name__ != "_nop":
-                #     file = Path(fcn.__code__.co_filename).name
-                #     line = fcn.__code__.co_firstlineno
-                #     meta = "{" + file + "#" + str(line) + "}"
-                #     evt += f":[[{meta} {fcn.__name__}()]]\\n"
+                for trans_val in trans_vals:
+                    src = trans_val["from_state"]
+                    dest = trans_val["to_state"]
+                    if dest is None:
+                        dest = src
+                    action_name = trans_val["action"].__name__
+                    if action_name == "_nop":
+                        action_str = ""
+                    else:
+                        action_str = f" / {action_name}"
 
-                data += f"\t{src.name} --> {dest.name}: {evt}\n"
+                data += f"\t{src.name} --> {dest.name}: {evt}{action_str}\n"
 
         data += "\n"
 
@@ -1305,12 +1303,21 @@ class StateMachine(State):
         if note is not None and not isinstance(note, str):
             raise ValueError("Note must be a string")
 
-        data = f"# State Machine: {self.name}"
-        data += "# D2 State Diagram"
-        data += "# https://d2lang.com/"
+        data = f"# State Machine: {self.name}\n"
+        data += "# D2 State Diagram\n"
+        data += "# https://d2lang.com/\n"
 
         data += textwrap.dedent(
             """
+        # Specify Layout engine
+        # Default 'dagre' does not support self-transitions on
+        # hierarchical diagrams.
+        vars: {
+            d2-config: {
+                layout-engine: elk
+            }
+        }
+                
         # Special Classes
         classes: {
 

--- a/test/test_d2.py
+++ b/test/test_d2.py
@@ -13,7 +13,8 @@ def test():
     
     import test_complex_hsm
     sm = test_complex_hsm.m
-    sm.to_d2()
+    d2 = sm.to_d2()
+    assert len(d2) > 0
 
 if __name__ == '__main__':
     test()

--- a/test/test_d2.py
+++ b/test/test_d2.py
@@ -1,20 +1,53 @@
-# Append parent directory to path so we can access the pysm module
 import sys
-sys.path.append(r'..')
+sys.path.append(r'.')
 
+import pysm
 
-def test():
-    # Verify basic functionality remains unchanged
-    import test_simple_on_off
-    test_simple_on_off.test()
+def test_d2():
+    # Define general state machine for test
+    sm1 = pysm.StateMachine("sm1")
 
-    import test_complex_hsm
-    test_complex_hsm.test()
+    # Put a generic state in the SM
+    state1 = pysm.State("state1")
+    sm1.add_state(state1, initial=True)
     
-    import test_complex_hsm
-    sm = test_complex_hsm.m
-    d2 = sm.to_d2()
+    # Create a child SM
+    sm2 = pysm.StateMachine("sm2")
+    sm1.add_state(sm2)
+    sm1.add_transition(state1, sm2, events=["evt_state1->sm2"])
+
+    # Add a transition for the child SM that returns to itself
+    sm1.add_transition(sm2, None, events=["evt_sm2->sm2"])
+
+    # Add a transition for the child SM that returns to itself
+    def dummy_action(event, state):
+        pass
+    sm1.add_transition(sm2, None, events=["evt_sm2->sm2_func"], action=dummy_action)
+
+    # Create initial landing state for child SM
+    state2 = pysm.State("state2")
+    sm2.add_state(state2, initial=True)
+
+    # Add self-transition for this state
+    sm2.add_transition(state2, None, events=["evt_state2->state2"])
+
+    # Make new child state with other forms of transitions
+    state3 = pysm.State("state3")
+    sm2.add_state(state3)
+    sm2.add_transition(state2, state3, events=["evt_state2->state3_func"], action=dummy_action)
+    sm2.add_transition(state3, state2, events=["evt_state3->state2_func"], action=dummy_action)
+    sm2.add_transition(state3, state3, events=["evt_state3->state3_func"], action=dummy_action)
+    
+    # Intialise SM
+    sm1.initialize()
+
+    # Run tool to generate D2 graph
+    d2 = sm1.to_d2()
+
+    # Verify that the D2 graph is not empty.
     assert len(d2) > 0
 
+    # You can also check the output file: HSM-sm1.d2
+
 if __name__ == '__main__':
-    test()
+    test_d2()

--- a/test/test_d2.py
+++ b/test/test_d2.py
@@ -1,11 +1,19 @@
-from test_simple_on_off import sm, state_on, state_off
+# Append parent directory to path so we can access the pysm module
+import sys
+sys.path.append(r'..')
 
 
-def test_d2(complex_state_machine):
+def test():
+    # Verify basic functionality remains unchanged
+    import test_simple_on_off
+    test_simple_on_off.test()
 
-    sm = complex_state_machine
-    sm.initialize()
+    import test_complex_hsm
+    test_complex_hsm.test()
+    
+    import test_complex_hsm
+    sm = test_complex_hsm.m
+    sm.to_d2()
 
-    d2 = sm.to_d2()
-
-    assert len(d2) > 0
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
- Minor bugfix so no python error during d2 rendering if a state transitions to itself
- Explicitly specify rendering engine as default renderer has issues when a parent state machine has a transition to itself
- Add feature: if an action function is specified for a given transition, it will be shown on the graph